### PR TITLE
Edit post inoculation terms to include media

### DIFF
--- a/phi-eco.obo
+++ b/phi-eco.obo
@@ -4713,7 +4713,7 @@ creation_date: 2020-01-14T14:17:20Z
 [Term]
 id: PECO:0005225
 name: 1 day post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 day post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 day post inoculation." []
 synonym: "1 dpi" EXACT []
 synonym: "24 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
@@ -4723,7 +4723,7 @@ creation_date: 2020-03-10T14:29:30Z
 [Term]
 id: PECO:0005226
 name: 2 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 days post inoculation." []
 synonym: "2 dpi" EXACT []
 synonym: "48 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
@@ -4733,7 +4733,7 @@ creation_date: 2020-03-10T14:30:09Z
 [Term]
 id: PECO:0005227
 name: 8 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 8 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 8 days post inoculation." []
 synonym: "8 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4742,7 +4742,7 @@ creation_date: 2020-03-10T14:30:48Z
 [Term]
 id: PECO:0005228
 name: 14 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 14 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 14 days post inoculation." []
 synonym: "14 dpi" EXACT []
 synonym: "2 weeks post inoculation" EXACT []
 synonym: "2 wpi" EXACT []
@@ -4753,7 +4753,7 @@ creation_date: 2020-03-10T14:31:27Z
 [Term]
 id: PECO:0005229
 name: 13 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 13 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 13 days post inoculation." []
 synonym: "13 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4762,7 +4762,7 @@ creation_date: 2020-03-10T14:32:30Z
 [Term]
 id: PECO:0005230
 name: 9 weeks post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 weeks post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 weeks post inoculation." []
 synonym: "9 wpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4868,7 +4868,7 @@ creation_date: 2020-03-30T16:10:07Z
 [Term]
 id: PECO:0005245
 name: 3 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 days post inoculation." []
 synonym: "3 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4877,7 +4877,7 @@ creation_date: 2020-03-30T16:17:01Z
 [Term]
 id: PECO:0005246
 name: 4 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 days post inoculation." []
 synonym: "4 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4886,7 +4886,7 @@ creation_date: 2020-03-30T16:17:15Z
 [Term]
 id: PECO:0005247
 name: 5 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 5 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 5 days post inoculation." []
 synonym: "5 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4895,7 +4895,7 @@ creation_date: 2020-03-30T16:17:32Z
 [Term]
 id: PECO:0005248
 name: 6 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 6 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 6 days post inoculation." []
 synonym: "6 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4904,7 +4904,7 @@ creation_date: 2020-03-30T16:17:45Z
 [Term]
 id: PECO:0005249
 name: 7 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 7 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 7 days post inoculation." []
 synonym: "1 week post inoculation" EXACT []
 synonym: "1 wpi" EXACT []
 synonym: "7 dpi" EXACT []
@@ -4915,7 +4915,7 @@ creation_date: 2020-03-30T16:18:43Z
 [Term]
 id: PECO:0005250
 name: 10 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 days post inoculation." []
 synonym: "10 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4924,7 +4924,7 @@ creation_date: 2020-03-30T16:19:16Z
 [Term]
 id: PECO:0005251
 name: 11 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 days post inoculation." []
 synonym: "11 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4933,7 +4933,7 @@ creation_date: 2020-03-30T16:19:32Z
 [Term]
 id: PECO:0005252
 name: 12 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 days post inoculation." []
 synonym: "12 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -4942,7 +4942,7 @@ creation_date: 2020-03-30T16:19:51Z
 [Term]
 id: PECO:0005253
 name: 20 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 days post inoculation." []
 synonym: "20 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5019,7 +5019,7 @@ creation_date: 2020-06-11T09:30:23Z
 [Term]
 id: PECO:0005262
 name: 22 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 22 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 22 days post inoculation." []
 synonym: "22 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5028,7 +5028,7 @@ creation_date: 2020-06-11T09:31:17Z
 [Term]
 id: PECO:0005263
 name: 3 weeks post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 weeks post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 weeks post inoculation." []
 synonym: "21 dpi" EXACT []
 synonym: "3 wpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
@@ -5063,7 +5063,7 @@ creation_date: 2020-06-12T09:34:51Z
 [Term]
 id: PECO:0005267
 name: 12 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 hours post inoculation." []
 synonym: "0.5 dpi" EXACT []
 synonym: "12 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
@@ -5073,7 +5073,7 @@ creation_date: 2020-06-12T09:34:51Z
 [Term]
 id: PECO:0005268
 name: 30 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 hours post inoculation." []
 synonym: "30 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5116,7 +5116,7 @@ creation_date: 2021-01-25T13:48:00Z
 [Term]
 id: PECO:0005273
 name: 2 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 hours post inoculation." []
 synonym: "2 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5125,7 +5125,7 @@ creation_date: 2021-01-27T11:24:28Z
 [Term]
 id: PECO:0005274
 name: 4 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 hours post inoculation." []
 synonym: "4 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5134,7 +5134,7 @@ creation_date: 2021-01-27T11:24:28Z
 [Term]
 id: PECO:0005275
 name: 1 hour post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 hour post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 hour post inoculation." []
 synonym: "1 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5143,7 +5143,7 @@ creation_date: 2021-01-27T11:24:28Z
 [Term]
 id: PECO:0005276
 name: 0.5 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.5 hours (30 minutes) post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.5 hours (30 minutes) post inoculation." []
 synonym: "0.5 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5152,7 +5152,7 @@ creation_date: 2021-01-27T11:24:28Z
 [Term]
 id: PECO:0005277
 name: 0.25 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.25 hours (15 minutes) post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.25 hours (15 minutes) post inoculation." []
 synonym: "0.25 hpi" EXACT []
 synonym: "15 minutes post inoculation" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
@@ -5207,7 +5207,7 @@ creation_date: 2021-03-19T12:42:48Z
 [Term]
 id: PECO:0005283
 name: 30 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 days post inoculation." []
 synonym: "30 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5216,7 +5216,7 @@ creation_date: 2021-04-14T12:19:27Z
 [Term]
 id: PECO:0005284
 name: 16 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 16 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 16 hours post inoculation." []
 synonym: "16 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5251,7 +5251,7 @@ creation_date: 2021-09-09T11:36:41Z
 [Term]
 id: PECO:0005288
 name: 11 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 hours post inoculation." []
 synonym: "11 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5260,7 +5260,7 @@ creation_date: 2022-06-15T10:50:17Z
 [Term]
 id: PECO:0005289
 name: 20 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 hours post inoculation." []
 synonym: "20 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5269,7 +5269,7 @@ creation_date: 2022-06-20T10:09:59Z
 [Term]
 id: PECO:0005290
 name: 3 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 hours post inoculation." []
 synonym: "3 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5286,7 +5286,7 @@ creation_date: 2022-06-20T10:14:37Z
 [Term]
 id: PECO:0005292
 name: 10 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 hours post inoculation." []
 synonym: "10 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5295,7 +5295,7 @@ creation_date: 2022-07-27T12:13:23Z
 [Term]
 id: PECO:0005293
 name: 40 hours post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 40 hours post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 40 hours post inoculation." []
 synonym: "40 hpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 created_by: alaynecuzick
@@ -5312,7 +5312,7 @@ creation_date: 2022-11-21T09:51:13Z
 [Term]
 id: PECO:0005295
 name: 9 days post inoculation
-def: "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 days post inoculation." []
+def: "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 days post inoculation." []
 synonym: "9 dpi" EXACT []
 is_a: PECO:0000122 ! grouping growth timing
 creation_date: 2022-11-22T10:28:49Z

--- a/phi-eco.owl
+++ b/phi-eco.owl
@@ -6678,7 +6678,7 @@ SubClassOf(obo:PECO_0005224 obo:PECO_0000080)
 
 # Class: obo:PECO_0005225 (1 day post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005225 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 day post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005225 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 day post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005225 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005225 "2020-03-10T14:29:30Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005225 "1 dpi")
@@ -6690,7 +6690,7 @@ SubClassOf(obo:PECO_0005225 obo:PECO_0000122)
 
 # Class: obo:PECO_0005226 (2 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005226 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005226 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005226 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005226 "2020-03-10T14:30:09Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005226 "2 dpi")
@@ -6701,7 +6701,7 @@ SubClassOf(obo:PECO_0005226 obo:PECO_0000122)
 
 # Class: obo:PECO_0005227 (8 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005227 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 8 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005227 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 8 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005227 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005227 "2020-03-10T14:30:48Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005227 "8 dpi")
@@ -6711,7 +6711,7 @@ SubClassOf(obo:PECO_0005227 obo:PECO_0000122)
 
 # Class: obo:PECO_0005228 (14 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005228 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 14 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005228 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 14 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005228 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005228 "2020-03-10T14:31:27Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005228 "14 dpi")
@@ -6723,7 +6723,7 @@ SubClassOf(obo:PECO_0005228 obo:PECO_0000122)
 
 # Class: obo:PECO_0005229 (13 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005229 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 13 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005229 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 13 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005229 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005229 "2020-03-10T14:32:30Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005229 "13 dpi")
@@ -6733,7 +6733,7 @@ SubClassOf(obo:PECO_0005229 obo:PECO_0000122)
 
 # Class: obo:PECO_0005230 (9 weeks post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005230 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 weeks post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005230 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 weeks post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005230 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005230 "2020-03-11T09:54:32Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005230 "9 wpi")
@@ -6852,7 +6852,7 @@ SubClassOf(obo:PECO_0005244 obo:PECO_0005239)
 
 # Class: obo:PECO_0005245 (3 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005245 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005245 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005245 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005245 "2020-03-30T16:17:01Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005245 "3 dpi")
@@ -6862,7 +6862,7 @@ SubClassOf(obo:PECO_0005245 obo:PECO_0000122)
 
 # Class: obo:PECO_0005246 (4 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005246 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005246 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005246 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005246 "2020-03-30T16:17:15Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005246 "4 dpi")
@@ -6872,7 +6872,7 @@ SubClassOf(obo:PECO_0005246 obo:PECO_0000122)
 
 # Class: obo:PECO_0005247 (5 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005247 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 5 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005247 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 5 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005247 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005247 "2020-03-30T16:17:32Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005247 "5 dpi")
@@ -6882,7 +6882,7 @@ SubClassOf(obo:PECO_0005247 obo:PECO_0000122)
 
 # Class: obo:PECO_0005248 (6 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005248 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 6 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005248 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 6 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005248 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005248 "2020-03-30T16:17:45Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005248 "6 dpi")
@@ -6892,7 +6892,7 @@ SubClassOf(obo:PECO_0005248 obo:PECO_0000122)
 
 # Class: obo:PECO_0005249 (7 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005249 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 7 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005249 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 7 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005249 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005249 "2020-03-30T16:18:43Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005249 "1 week post inoculation")
@@ -6904,7 +6904,7 @@ SubClassOf(obo:PECO_0005249 obo:PECO_0000122)
 
 # Class: obo:PECO_0005250 (10 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005250 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005250 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005250 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005250 "2020-03-30T16:19:16Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005250 "10 dpi")
@@ -6914,7 +6914,7 @@ SubClassOf(obo:PECO_0005250 obo:PECO_0000122)
 
 # Class: obo:PECO_0005251 (11 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005250 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005250 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005251 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005251 "2020-03-30T16:19:32Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005251 "11 dpi")
@@ -6924,7 +6924,7 @@ SubClassOf(obo:PECO_0005251 obo:PECO_0000122)
 
 # Class: obo:PECO_0005252 (12 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005252 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005252 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005252 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005252 "2020-03-30T16:19:51Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005252 "12 dpi")
@@ -6934,7 +6934,7 @@ SubClassOf(obo:PECO_0005252 obo:PECO_0000122)
 
 # Class: obo:PECO_0005253 (20 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005253 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 days post inoculation.")
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005253 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 days post inoculation.")
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005253 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005253 "2020-03-30T16:20:16Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005253 "20 dpi")
@@ -7028,7 +7028,7 @@ SubClassOf(obo:PECO_0005261 obo:PECO_0000120)
 
 # Class: obo:PECO_0005262 (22 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005262 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 22 days post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005262 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 22 days post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005262 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005262 "2020-06-11T09:31:17Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005262 "22 dpi"^^xsd:string)
@@ -7039,7 +7039,7 @@ SubClassOf(obo:PECO_0005262 obo:PECO_0000122)
 
 # Class: obo:PECO_0005263 (3 weeks post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005263 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 weeks post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005263 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 weeks post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005263 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005263 "2020-06-11T09:34:51Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005263 "21 dpi"^^xsd:string)
@@ -7082,7 +7082,7 @@ SubClassOf(obo:PECO_0005266 obo:PECO_0000109)
 
 # Class: obo:PECO_0005267 (12 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005267 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005267 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 12 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005267 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005267 "2020-06-12T09:34:51Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005267 "0.5 dpi"^^xsd:string)
@@ -7094,7 +7094,7 @@ SubClassOf(obo:PECO_0005267 obo:PECO_0000122)
 
 # Class: obo:PECO_0005268 (30 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005268 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005268 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005268 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005268 "2020-06-12T09:34:51Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005268 "30 hpi"^^xsd:string)
@@ -7147,7 +7147,7 @@ SubClassOf(obo:PECO_0005272 obo:PECO_0005233)
 
 # Class: obo:PECO_0005273 (2 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005273 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005273 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 2 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005273 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005273 "2021-01-27T11:24:28Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005273 "2 hpi"^^xsd:string)
@@ -7158,7 +7158,7 @@ SubClassOf(obo:PECO_0005273 obo:PECO_0000122)
 
 # Class: obo:PECO_0005274 (4 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005274 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005274 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 4 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005274 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005274 "2021-01-27T11:24:28Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005274 "4 hpi"^^xsd:string)
@@ -7169,7 +7169,7 @@ SubClassOf(obo:PECO_0005274 obo:PECO_0000122)
 
 # Class: obo:PECO_0005275 (1 hour post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005275 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 hour post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005275 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 1 hour post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005275 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005275 "2021-01-27T11:24:28Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005275 "1 hpi"^^xsd:string)
@@ -7180,7 +7180,7 @@ SubClassOf(obo:PECO_0005275 obo:PECO_0000122)
 
 # Class: obo:PECO_0005276 (0.5 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005276 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.5 hours (30 minutes) post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005276 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.5 hours (30 minutes) post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005276 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005276 "2021-01-27T11:24:28Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005276 "0.5 hpi"^^xsd:string)
@@ -7191,7 +7191,7 @@ SubClassOf(obo:PECO_0005276 obo:PECO_0000122)
 
 # Class: obo:PECO_0005277 (0.25 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005277 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.25 hours (15 minutes) post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005277 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 0.25 hours (15 minutes) post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005277 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005277 "2021-01-29T14:12:53Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005277 "0.25 hpi"^^xsd:string)
@@ -7258,7 +7258,7 @@ SubClassOf(obo:PECO_0005282 obo:PECO_0000109)
 
 # Class: obo:PECO_0005283 (30 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005283 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 days post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005283 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 30 days post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005283 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005283 "2021-04-14T12:19:27Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005283 "30 dpi"^^xsd:string)
@@ -7269,7 +7269,7 @@ SubClassOf(obo:PECO_0005283 obo:PECO_0000122)
 
 # Class: obo:PECO_0005284 (16 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005284 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 16 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005284 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 16 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005284 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005284 "2021-04-20T10:51:14Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005284 "16 hpi"^^xsd:string)
@@ -7312,7 +7312,7 @@ SubClassOf(obo:PECO_0005287 obo:PECO_0000109)
 
 # Class: obo:PECO_0005288 (11 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005288 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005288 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 11 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005288 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005288 "2022-06-15T10:50:17Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005288 "11 hpi"^^xsd:string)
@@ -7323,7 +7323,7 @@ SubClassOf(obo:PECO_0005288 obo:PECO_0000122)
 
 # Class: obo:PECO_0005289 (20 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005289 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005289 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 20 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005289 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005289 "2022-06-20T10:09:59Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005289 "20 hpi"^^xsd:string)
@@ -7334,7 +7334,7 @@ SubClassOf(obo:PECO_0005289 obo:PECO_0000122)
 
 # Class: obo:PECO_0005290 (3 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005290 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005290 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 3 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005290 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005290 "2022-06-20T10:10:39Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005290 "3 hpi"^^xsd:string)
@@ -7355,7 +7355,7 @@ SubClassOf(obo:PECO_0005291 obo:PECO_0005233)
 
 # Class: obo:PECO_0005292 (10 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005292 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005292 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 10 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005292 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005292 "2022-07-27T12:13:23Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005292 "10 hpi"^^xsd:string)
@@ -7366,7 +7366,7 @@ SubClassOf(obo:PECO_0005292 obo:PECO_0000122)
 
 # Class: obo:PECO_0005293 (40 hours post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005293 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 40 hours post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005293 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 40 hours post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PECO_0005293 "alaynecuzick"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005293 "2022-07-27T12:13:23Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005293 "40 hpi"^^xsd:string)
@@ -7387,7 +7387,7 @@ SubClassOf(obo:PECO_0005294 obo:PECO_0000122)
 
 # Class: obo:PECO_0005295 (9 days post inoculation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005295 "Host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 days post inoculation."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000115 obo:PECO_0005295 "Media or host organisms were inoculated with a pathogen or pathogen derived construct and observed at 9 days post inoculation."^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PECO_0005295 "2022-11-22T10:28:49Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:PECO_0005295 "9 dpi"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:PECO_0005295 "phenotype_condition"^^xsd:string)


### PR DESCRIPTION
(Closes #12)

This pull request edits the time-post-inoculation terms to specify media as well as host organisms.

@CuzickA Can you check the changes [here](https://github.com/PHI-base/phi-eco/pull/30/files) to see whether they're what you expected? I counted 32 terms in total by searching for 'post inoculation' in term labels.